### PR TITLE
Add .gitignore file to exclude unnecessary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# Python virtual environment
+venv/
+
+# Byte-compiled Python files
+__pycache__/
+*.pyc
+
+# IDE and editor files
+.vscode/
+.idea/
+*.swp # Vim swap files
+*.iml # IntelliJ IDEA module files
+
+# Operating System files
+.DS_Store # macOS
+Thumbs.db # Windows
+
+# Misc
+*.log
+*.tmp
+*.bak
+*.swp
+
+# Jupyter Notebook checkpoints
+.ipynb_checkpoints/
+
+# Build and output directories
+/dist
+/build
+/out


### PR DESCRIPTION
This PR adds a `.gitignore` file to the root of the project to exclude common unnecessary files like virtual environments, cache folders, and IDE-specific files. This helps keep our repository clean and focused on essential code.