### PR TITLE
fix: FAQ page now loads real data from database

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -44,6 +44,8 @@ urlpatterns = [
 
     # FAQ
     path("faq/", views.faq, name="faq"),
+    path("faq/add/", views.add_faq, name="add_faq"),
+    path("faq/delete/<int:faq_id>/", views.delete_faq, name="delete_faq"),
 
     # API
     path("api/auth-check/", views.auth_check, name="auth_check"),

--- a/core/views.py
+++ b/core/views.py
@@ -7,6 +7,7 @@ from django.db.models import Q, F
 from .models import SuccessStory, StoryReaction, StudyNote
 from .forms import SuccessStoryForm
 import json
+from .models import FAQ
 
 def index(request):
     return render(request, "index.html")
@@ -49,7 +50,30 @@ def profile(request):
     return render(request, "profile.html")
 
 def faq(request):
-    return render(request, "add_faq.html")
+    faqs = FAQ.objects.filter(is_active=True).order_by('order', '-created_at')
+    return render(request, "faq.html", {"faqs": faqs})
+@login_required
+def add_faq(request):
+    if not request.user.is_superuser:
+        return redirect("faq")
+    if request.method == "POST":
+        question = request.POST.get("question", "").strip()
+        answer = request.POST.get("answer", "").strip()
+        if question and answer:
+            FAQ.objects.create(question=question, answer=answer)
+            messages.success(request, "FAQ added successfully!")
+        return redirect("faq")
+    return redirect("faq")
+
+@login_required  
+def delete_faq(request, faq_id):
+    if not request.user.is_superuser:
+        return redirect("faq")
+    faq_obj = get_object_or_404(FAQ, id=faq_id)
+    faq_obj.delete()
+    messages.success(request, "FAQ deleted.")
+    return redirect("faq")
+
 
 @login_required
 def questions(request):


### PR DESCRIPTION
## What this PR does

The FAQ page existed but was completely broken — it rendered the 
wrong template and passed no data to it, so users always saw 
"No FAQs have been added yet" even if FAQs existed in the database.

## Changes

**core/views.py**
- Fixed `faq` view to render `faq.html` instead of `add_faq.html`
- Added queryset `FAQ.objects.filter(is_active=True)` so FAQs 
  actually show up
- Added `add_faq` view so superusers can add FAQs via the modal
- Added `delete_faq` view so superusers can remove FAQs
- Added `is_superuser` permission guard on both add and delete

**core/urls.py**
- Added missing route `faq/add/` → `add_faq`
- Added missing route `faq/delete/<id>/` → `delete_faq`
  (these were referenced in the template but never registered)

## Why it matters

The FAQ model and template were already fully built. 
This just connects them — no new dependencies, no new migrations.

## How to test

1. Run the server
2. Login as superuser, go to `/faq/`
3. Click "Add FAQ", fill the form, submit
4. FAQ appears on the page
5. Click delete icon to remove it
6. Logout — verify add/delete buttons are hidden from regular users